### PR TITLE
Tables now fill the page horizontally

### DIFF
--- a/src/components/shared/Table.js
+++ b/src/components/shared/Table.js
@@ -7,6 +7,7 @@ export default function Table({ title, data, columns, marginTop, grouping }) {
     <MaterialTable
       style={{
         maxWidth: "100%",
+        width: "100%",
         marginBottom: "1rem",
         marginTop: marginTop != undefined ? "1rem" : null,
       }}


### PR DESCRIPTION
Just a simple change to make the tables fill the page.

Took a quick look at how mobile-friendly everything is. For the most part, things work fine, only thing that really doesn't is the table. Not really sure how to fix that since tables are kinda inherently mobile-unfriendly.