### PR TITLE
Fix duplicate key issue when rendering index column

### DIFF
--- a/src/components/shared/ColumnHelper.js
+++ b/src/components/shared/ColumnHelper.js
@@ -15,13 +15,13 @@ export function indexRender(value, tableMeta, bookData, currentBook) {
           .filter(node => node.generatedId === idAndPage[0])
         
         return currentBook !== idAndPage[0] ? (
-          <span key={tableMeta.rowData[GENERATED_ID_COL_INDEX]}>
+          <span key={`${tableMeta.rowData[GENERATED_ID_COL_INDEX]}-${count}`}>
             <Link to={`/books/${idAndPage[0]}/`}>{book[0].name}</Link>:
             {idAndPage[1]}
             {count !== indices.length - 1 ? ", " : ""}
           </span>
         ) : (
-          <span key={tableMeta.rowData[GENERATED_ID_COL_INDEX]}>
+          <span key={`${tableMeta.rowData[GENERATED_ID_COL_INDEX]}-${count}`}>
             {book[0].name}:{idAndPage[1]}
             {count !== indices.length - 1 ? ", " : ""}
           </span>


### PR DESCRIPTION
Hopefully closes #166 

Hard to tell because the behaviour is very inconsistent, so there's no 100% reproduction case, but this does fix the duplicate key error that was all over the console and is very likely the culprit.