### PR TITLE
Brawn melee display

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,6 +30,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String!
       skill: String
       damage: Int
+      brawn: Boolean
       crit: String
       range: String
       special: String
@@ -74,6 +75,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String!
       skill: String
       damage: String
+      brawn: Boolean
       crit: String
       range: String
       special: String
@@ -204,6 +206,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       category: String
       skill: String
       damage: Int
+      brawn: Boolean
       crit: String
       range: String
       encumbrance: Int

--- a/src/components/AdversariesWeaponsColumnProvider.js
+++ b/src/components/AdversariesWeaponsColumnProvider.js
@@ -50,7 +50,7 @@ function AdversariesWeaponsColumnProvider({ children, currentBook, metadata }) {
     },
   ])
 
-  return React.cloneElement(React.Children.only(children), { columns })
+  return React.cloneElement(React.Children.only(children), { columns, metadata })
 }
 
 AdversariesWeaponsColumnProvider.propTypes = {

--- a/src/components/AdversariesWeaponsColumnProvider.js
+++ b/src/components/AdversariesWeaponsColumnProvider.js
@@ -1,9 +1,15 @@
 import React from "react"
 import Link from "./shared/Link"
-import { makeColumns, GENERATED_ID_COL_INDEX, indexRender } from "./shared/ColumnHelper"
+import {
+  makeColumns,
+  GENERATED_ID_COL_INDEX,
+  indexRender,
+  damageRender,
+  ColumnProviderPropTypes
+} from "./shared/ColumnHelper"
 import ProvideBookData from "./shared/BookDataProvider"
 
-export default function AdversariesWeaponsColumnProvider({children, currentBook}){
+function AdversariesWeaponsColumnProvider({ children, currentBook, metadata }) {
   let bookData = ProvideBookData()
   let columns = makeColumns([
     {
@@ -22,7 +28,14 @@ export default function AdversariesWeaponsColumnProvider({children, currentBook}
       },
     },
     { label: "Skill", name: "skill" },
-    { label: "Damage", name: "damage" },
+    {
+      label: "Damage",
+      name: "damage",
+      options: {
+        customBodyRender: (value, tableMeta) =>
+          damageRender(value, tableMeta, metadata),
+      },
+    },
     { label: "Crit", name: "crit" },
     { label: "Range", name: "range" },
     { label: "Special", name: "special" },
@@ -39,3 +52,9 @@ export default function AdversariesWeaponsColumnProvider({children, currentBook}
 
   return React.cloneElement(React.Children.only(children), { columns })
 }
+
+AdversariesWeaponsColumnProvider.propTypes = {
+  ...ColumnProviderPropTypes,
+}
+
+export default AdversariesWeaponsColumnProvider

--- a/src/components/CreaturesWeaponsColumnProvider.js
+++ b/src/components/CreaturesWeaponsColumnProvider.js
@@ -39,7 +39,7 @@ function CreaturesWeaponsColumnProvider({children, currentBook, metadata}) {
     },
   ])
 
-  return React.cloneElement(React.Children.only(children), { columns })
+  return React.cloneElement(React.Children.only(children), { columns, metadata })
 }
 
 CreaturesWeaponsColumnProvider.propTypes = {

--- a/src/components/CreaturesWeaponsColumnProvider.js
+++ b/src/components/CreaturesWeaponsColumnProvider.js
@@ -1,9 +1,9 @@
 import React from "react"
 import Link from "./shared/Link"
-import { makeColumns, GENERATED_ID_COL_INDEX, indexRender } from "./shared/ColumnHelper"
+import { makeColumns, GENERATED_ID_COL_INDEX, indexRender, damageRender, ColumnProviderPropTypes } from "./shared/ColumnHelper"
 import ProvideBookData from "./shared/BookDataProvider"
 
-export default function CreaturesWeaponsColumnProvider({children, currentBook}) {
+function CreaturesWeaponsColumnProvider({children, currentBook, metadata}) {
   let bookData = ProvideBookData()
   let columns = makeColumns([
     {
@@ -22,7 +22,9 @@ export default function CreaturesWeaponsColumnProvider({children, currentBook}) 
       },
     },
     { label: "Skill", name: "skill" },
-    { label: "Damage", name: "damage" },
+    { label: "Damage", name: "damage", options: {
+      customBodyRender: (value, tableMeta) => damageRender(value, tableMeta, metadata)
+    } },
     { label: "Crit", name: "crit" },
     { label: "Range", name: "range" },
     { label: "Special", name: "special" },
@@ -39,3 +41,9 @@ export default function CreaturesWeaponsColumnProvider({children, currentBook}) 
 
   return React.cloneElement(React.Children.only(children), { columns })
 }
+
+CreaturesWeaponsColumnProvider.propTypes = {
+  ...ColumnProviderPropTypes
+}
+
+export default CreaturesWeaponsColumnProvider

--- a/src/components/WeaponsColumnProvider.js
+++ b/src/components/WeaponsColumnProvider.js
@@ -64,7 +64,7 @@ function WeaponsColumnProvider({ children, currentBook, metadata }) {
     },
   ])
 
-  return React.cloneElement(React.Children.only(children), { columns })
+  return React.cloneElement(React.Children.only(children), { columns, metadata })
 }
 
 WeaponsColumnProvider.propTypes = {

--- a/src/components/WeaponsColumnProvider.js
+++ b/src/components/WeaponsColumnProvider.js
@@ -1,14 +1,15 @@
 import React from "react"
 import Link from "./shared/Link"
 import {
-  RESTRICTED_COL_INDEX,
   GENERATED_ID_COL_INDEX,
   makeColumns,
-  indexRender
+  indexRender,
+  damageRender,
+  ColumnProviderPropTypes,
 } from "./shared/ColumnHelper"
 import ProvideBookData from "./shared/BookDataProvider"
 
-export default function WeaponsColumnProvider({children, currentBook}) {
+function WeaponsColumnProvider({ children, currentBook, metadata }) {
   let bookData = ProvideBookData()
   let columns = makeColumns([
     {
@@ -26,7 +27,14 @@ export default function WeaponsColumnProvider({children, currentBook}) {
     },
     { label: "Category", name: "category" },
     { label: "Skill", name: "skill" },
-    { label: "Damage", name: "damage" },
+    {
+      label: "Damage",
+      name: "damage",
+      options: {
+        customBodyRender: (value, tableMeta) =>
+          damageRender(value, tableMeta, metadata),
+      },
+    },
     { label: "Crit", name: "crit" },
     { label: "Range", name: "range" },
     { label: "Encum.", name: "encumbrance" },
@@ -37,7 +45,9 @@ export default function WeaponsColumnProvider({children, currentBook}) {
       options: {
         customBodyRender: (value, tableMeta) =>
           `${
-            tableMeta.rowData[RESTRICTED_COL_INDEX] ? "(R) " : ""
+            metadata[tableMeta.rowData[GENERATED_ID_COL_INDEX]].isRestricted
+              ? "(R) "
+              : ""
           }${value.toLocaleString()}`,
       },
     },
@@ -52,7 +62,13 @@ export default function WeaponsColumnProvider({children, currentBook}) {
           indexRender(value, tableMeta, bookData, currentBook),
       },
     },
-  ], true)
+  ])
 
   return React.cloneElement(React.Children.only(children), { columns })
 }
+
+WeaponsColumnProvider.propTypes = {
+  ...ColumnProviderPropTypes,
+}
+
+export default WeaponsColumnProvider

--- a/src/components/shared/ColumnHelper.js
+++ b/src/components/shared/ColumnHelper.js
@@ -15,13 +15,13 @@ export function indexRender(value, tableMeta, bookData, currentBook) {
           .filter(node => node.generatedId === idAndPage[0])
         
         return currentBook !== idAndPage[0] ? (
-          <span key={tableMeta.rowData[GENERATED_ID_COL_INDEX]}>
+          <span key={`${tableMeta.rowData[GENERATED_ID_COL_INDEX]}-${count}`}>
             <Link to={`/books/${idAndPage[0]}/`}>{book[0].name}</Link>:
             {idAndPage[1]}
             {count !== indices.length - 1 ? ", " : ""}
           </span>
         ) : (
-          <span key={tableMeta.rowData[GENERATED_ID_COL_INDEX]}>
+          <span key={`${tableMeta.rowData[GENERATED_ID_COL_INDEX]}-${count}`}>
             {book[0].name}:{idAndPage[1]}
             {count !== indices.length - 1 ? ", " : ""}
           </span>

--- a/src/components/shared/ColumnHelper.js
+++ b/src/components/shared/ColumnHelper.js
@@ -1,4 +1,5 @@
 import * as React from "react"
+import PropTypes from "prop-types"
 import Link from "../shared/Link"
 
 export const GENERATED_ID_COL_INDEX = 0
@@ -52,6 +53,22 @@ export function indexRender(value, tableMeta, bookData, currentBook) {
       })}
     </div>
   )
+}
+
+export const ColumnProviderPropTypes = {
+  children: PropTypes.element.isRequired,
+  currentBook: PropTypes.string,
+  //metadata is a dictionary that maps generatedId to the object 
+  //of the shape described here
+  metadata: PropTypes.objectOf({
+    isRestricted: PropTypes.bool,
+    isBrawn: PropTypes.bool
+  })
+}
+
+//columnMeta will be the metadata object described in ColumnProviderPropTypes
+export function damageRender(value, tableMeta, columnMeta) {
+  return `${columnMeta[tableMeta.rowData[GENERATED_ID_COL_INDEX]].isBrawn ? "+" : ""}${value}`
 }
 
 export const makeColumns = (columns, includeRestricted) => {

--- a/src/components/shared/StatPage.js
+++ b/src/components/shared/StatPage.js
@@ -6,13 +6,14 @@ import SEO from "./SEO"
 import Table from "./Table"
 import { Container } from "@material-ui/core"
 
-export default function StatPage({ title, columns, data, noGrouping }) {
+export default function StatPage({ title, columns, data, metadata, noGrouping }) {
   return (
     <Dashboard>
       <SEO title={title} />
         <Table
           title={title}
           columns={columns}
+          metadata={metadata}
           grouping={noGrouping && "false"}
           data={data.edges.map(({ node }) => {
             return {

--- a/src/components/shared/Table.js
+++ b/src/components/shared/Table.js
@@ -4,8 +4,16 @@ import Typography from "@material-ui/core/Typography"
 import useMediaQuery from "@material-ui/core/useMediaQuery"
 import { createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles"
 import ProvideBookData from "./BookDataProvider"
+import { GENERATED_ID_COL_INDEX } from "./ColumnHelper"
 
-export default function Table({ title, data, columns, marginTop, grouping }) {
+export default function Table({
+  title,
+  data,
+  columns,
+  metadata,
+  marginTop,
+  grouping,
+}) {
   let bookData = ProvideBookData()
 
   let getMuiTheme = () => {
@@ -80,6 +88,54 @@ export default function Table({ title, data, columns, marginTop, grouping }) {
         data={data}
         options={{
           sort: true,
+          customSort: (data, colIndex, order) => {
+            switch (columns[colIndex].name) {
+              case "damage": {
+                return data.sort((a, b) => {
+                  let aData =
+                    a.data[colIndex] === null ||
+                    typeof a.data[colIndex] === "undefined"
+                      ? ""
+                      : a.data[colIndex]
+                  let bData =
+                    b.data[colIndex] === null ||
+                    typeof b.data[colIndex] === "undefined"
+                      ? ""
+                      : b.data[colIndex]
+                  let aMeta = metadata[a.data[GENERATED_ID_COL_INDEX]]
+                  let bMeta = metadata[b.data[GENERATED_ID_COL_INDEX]]
+
+                  if (aData === bData) {
+                    if (aMeta.isBrawn === true && bMeta.isBrawn !== true)
+                      return order === "desc" ? -1 : 1
+                    else if (bMeta.isBrawn === true && aMeta.isBrawn !== true)
+                      return order === "desc" ? 1 : -1
+                  }
+
+                  return (aData - bData) * (order === "desc" ? -1 : 1)
+                })
+              }
+              default: {
+                return data.sort((a, b) => {
+                  let aData =
+                    a.data[colIndex] === null ||
+                    typeof a.data[colIndex] === "undefined"
+                      ? ""
+                      : a.data[colIndex]
+                  let bData =
+                    b.data[colIndex] === null ||
+                    typeof b.data[colIndex] === "undefined"
+                      ? ""
+                      : b.data[colIndex]
+                  return (
+                    (typeof aData.localeCompare === "function"
+                      ? aData.localeCompare(bData)
+                      : aData - bData) * (order === "desc" ? -1 : 1)
+                  )
+                })
+              }
+            }
+          },
           download: true,
           onDownload: (buildHead, buildBody, columns, data) => {
             let indexCol = columns.findIndex(c => c.name === "index")
@@ -87,7 +143,9 @@ export default function Table({ title, data, columns, marginTop, grouping }) {
               d.data[indexCol] = d.data[indexCol].split(",").map(index => {
                 let idAndPage = index.split(":").map(s => s.trim())
                 return (
-                  bookData.allBooksYaml.edges.map(({node}) => node).filter(b => b.generatedId === idAndPage[0])[0].name +
+                  bookData.allBooksYaml.edges
+                    .map(({ node }) => node)
+                    .filter(b => b.generatedId === idAndPage[0])[0].name +
                   ":" +
                   idAndPage[1]
                 )

--- a/src/pages/adversaries-weapons.js
+++ b/src/pages/adversaries-weapons.js
@@ -5,7 +5,16 @@ import AdversariesWeaponsColumnProvider from "../components/AdversariesWeaponsCo
 
 export default function AdversariesWeapons({ data }) {
   return (
-    <AdversariesWeaponsColumnProvider>
+    <AdversariesWeaponsColumnProvider
+      metadata={data.allAdversariesWeaponsYaml.edges
+        .map(({ node }) => node)
+        .reduce((acc, cur) => {
+          acc[cur.generatedId] = {
+            isBrawn: cur.brawn,
+          }
+          return acc
+        }, {})}
+    >
       <StatPage
         title="Adversaries Weapons"
         data={data.allAdversariesWeaponsYaml}
@@ -22,6 +31,7 @@ export const query = graphql`
           name
           skill
           damage
+          brawn
           crit
           range
           special

--- a/src/pages/creatures-weapons.js
+++ b/src/pages/creatures-weapons.js
@@ -5,11 +5,17 @@ import CreaturesWeaponsColumnProvider from "../components/CreaturesWeaponsColumn
 
 export default function CreaturesWeapons({ data }) {
   return (
-    <CreaturesWeaponsColumnProvider>
-      <StatPage
-        title="Creatures Weapons"
-        data={data.allCreaturesWeaponsYaml}
-      />
+    <CreaturesWeaponsColumnProvider
+      metadata={data.allCreaturesWeaponsYaml.edges
+        .map(({ node }) => node)
+        .reduce((acc, cur) => {
+          acc[cur.generatedId] = {
+            isBrawn: cur.brawn,
+          }
+          return acc
+        }, {})}
+    >
+      <StatPage title="Creatures Weapons" data={data.allCreaturesWeaponsYaml} />
     </CreaturesWeaponsColumnProvider>
   )
 }
@@ -22,6 +28,7 @@ export const query = graphql`
           name
           skill
           damage
+          brawn
           crit
           range
           special

--- a/src/pages/weapons.js
+++ b/src/pages/weapons.js
@@ -5,11 +5,18 @@ import WeaponsColumnProvider from "../components/WeaponsColumnProvider"
 
 export default function Weapons({ data }) {
   return (
-    <WeaponsColumnProvider>
-      <StatPage
-        title="Weapons"
-        data={data.allWeaponsYaml}
-      />
+    <WeaponsColumnProvider
+      metadata={data.allWeaponsYaml.edges
+        .map(({ node }) => node)
+        .reduce((acc, cur) => {
+          acc[cur.generatedId] = {
+            isRestricted: cur.restricted,
+            isBrawn: cur.brawn,
+          }
+          return acc
+        }, {})}
+    >
+      <StatPage title="Weapons" data={data.allWeaponsYaml} />
     </WeaponsColumnProvider>
   )
 }
@@ -23,6 +30,7 @@ export const query = graphql`
           category
           skill
           damage
+          brawn
           crit
           range
           encumbrance

--- a/src/templates/books.js
+++ b/src/templates/books.js
@@ -44,7 +44,18 @@ export default ({ data, location }) => {
             marginTop
           />
         </GearColumnProvider>
-        <WeaponsColumnProvider currentBook={data.booksYaml.generatedId}>
+        <WeaponsColumnProvider
+          currentBook={data.booksYaml.generatedId}
+          metadata={data.allWeaponsYaml.edges
+            .map(({ node }) => node)
+            .reduce((acc, cur) => {
+              acc[cur.generatedId] = {
+                isRestricted: cur.restricted,
+                isBrawn: cur.brawn,
+              }
+              return acc
+            }, {})}
+        >
           <Table
             title="Weapons"
             data={data.allWeaponsYaml.edges.map(({ node }) => {
@@ -170,6 +181,14 @@ export default ({ data, location }) => {
         </AdversariesGearColumnProvider>
         <AdversariesWeaponsColumnProvider
           currentBook={data.booksYaml.generatedId}
+          metadata={data.allAdversariesWeaponsYaml.edges
+            .map(({ node }) => node)
+            .reduce((acc, cur) => {
+              acc[cur.generatedId] = {
+                isBrawn: cur.brawn,
+              }
+              return acc
+            }, {})}
         >
           <Table
             title="Adversaries Weapons"
@@ -204,6 +223,14 @@ export default ({ data, location }) => {
         </CreaturesColumnProvider>
         <CreaturesWeaponsColumnProvider
           currentBook={data.booksYaml.generatedId}
+          metadata={data.allCreaturesWeaponsYaml.edges
+            .map(({ node }) => node)
+            .reduce((acc, cur) => {
+              acc[cur.generatedId] = {
+                isBrawn: cur.brawn,
+              }
+              return acc
+            }, {})}
         >
           <Table
             title="Creatures Weapons"
@@ -235,11 +262,13 @@ export const query = graphql`
           category
           skill
           damage
+          brawn
           crit
           range
           encumbrance
           hp
           price
+          restricted
           rarity
           special
           index
@@ -420,6 +449,7 @@ export const query = graphql`
           name
           skill
           damage
+          brawn
           crit
           range
           special
@@ -461,6 +491,7 @@ export const query = graphql`
           name
           skill
           damage
+          brawn
           crit
           range
           special

--- a/src/templates/qualities.js
+++ b/src/templates/qualities.js
@@ -16,7 +16,17 @@ export default ({ data, location }) => {
         location={location}
       />
       <Grid container item xs={12}>
-        <WeaponsColumnProvider>
+        <WeaponsColumnProvider
+          metadata={data.allWeaponsYaml.edges
+            .map(({ node }) => node)
+            .reduce((acc, cur) => {
+              acc[cur.generatedId] = {
+                isRestricted: cur.restricted,
+                isBrawn: cur.brawn,
+              }
+              return acc
+            }, {})}
+        >
           <Table
             marginTop
             title="Weapons"
@@ -27,7 +37,16 @@ export default ({ data, location }) => {
             })}
           />
         </WeaponsColumnProvider>
-        <AdversariesWeaponsColumnProvider>
+        <AdversariesWeaponsColumnProvider
+          metadata={data.allAdversariesWeaponsYaml.edges
+            .map(({ node }) => node)
+            .reduce((acc, cur) => {
+              acc[cur.generatedId] = {
+                isBrawn: cur.brawn,
+              }
+              return acc
+            }, {})}
+        >
           <Table
             marginTop
             title="Adversaries Weapons"
@@ -59,11 +78,13 @@ export const query = graphql`
           category
           skill
           damage
+          brawn
           crit
           range
           encumbrance
           hp
           price
+          restricted
           rarity
           special
           index
@@ -77,6 +98,7 @@ export const query = graphql`
           name
           skill
           damage
+          brawn
           crit
           range
           special


### PR DESCRIPTION
Implements the display of a '+' in the damage column of any weapon table (including adversary and creature weapons) whenever that weapon's damage in enhanced by the character's brawn rating.

Note: This PR is only the implementation. While some newer data already includes this, all the old data still needs to be updated to include brawn: true || false